### PR TITLE
add downloadOptions and interlex keyword annotation

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -156,6 +156,14 @@
         }
       ]
     },
+	{
+		"category": "downloadOptions",
+		"values": [
+			{
+				"value": "offsite"
+			}
+		]
+	},
     {
       "category": "REB_statement",
       "values": [

--- a/DATS.json
+++ b/DATS.json
@@ -10,7 +10,8 @@
   "types": [
     {
       "information": {
-        "value": "BAM"
+        "value": "BAM",
+		"valueIRI": "http://uri.interlex.org/ilx_0778671"
       }
     },
     {
@@ -20,7 +21,8 @@
     },
     {
       "information": {
-        "value": "VCF"
+        "value": "VCF",
+		"valueIRI": "http://uri.interlex.org/ilx_0778344"
       }
     }
   ],


### PR DESCRIPTION
This PR adds a dummy "offsite" value to the `downloadOptions` field, and interlex annotations to keywords, in the DATS.json file.